### PR TITLE
Fix image paths for Orca Slicer

### DIFF
--- a/docs/slicers/orcaslicer.md
+++ b/docs/slicers/orcaslicer.md
@@ -7,15 +7,15 @@ Here you will find custom build plates for OrcaSlicer:
 
 | Creality K1/K1C |
 | :---------: |
-| <img src="../../assets/img/OrcaSlicer/K1.png"> |
+| <img src="../assets/img/OrcaSlicer/K1.png"> |
 
 | Creality K1 Max without LiDAR Area |
 | :---------: |
-| <img src="../../assets/img/OrcaSlicer/K1_Max_without_LiDAR.png"> |
+| <img src="../assets/img/OrcaSlicer/K1_Max_without_LiDAR.png"> |
 
 | Creality K1 Max with LiDAR Area |
 | :---------: |
-| <img src="../../assets/img/OrcaSlicer/K1_Max_with_LiDAR.png"> |
+| <img src="../assets/img/OrcaSlicer/K1_Max_with_LiDAR.png"> |
 
 
 ## Download Links
@@ -33,15 +33,15 @@ Here you will find custom build plates for OrcaSlicer:
 
 - Start **OrcaSlicer** and click on the icon for editing printer presets:
 
-    <img width="600" src="../../assets/img/OrcaSlicer/OrcaSlicer_01.png">
+    <img width="600" src="../assets/img/OrcaSlicer/OrcaSlicer_01.png">
 
 - Click on `Set...` button in `Printable area` section:
 
-    <img width="600" src="../../assets/img/OrcaSlicer/OrcaSlicer_02.png">
+    <img width="600" src="../assets/img/OrcaSlicer/OrcaSlicer_02.png">
 
 - Load the PNG file (the one you want) in the `Texture` box and the file `Build_Plate.stl` in the `Model` box by clicking on `Load...` button:
 
-    <img width="600" src="../../assets/img/OrcaSlicer/OrcaSlicer_03.png">
+    <img width="600" src="../assets/img/OrcaSlicer/OrcaSlicer_03.png">
 
 - Then save your printer profile.
 
@@ -51,7 +51,7 @@ Here you will find custom build plates for OrcaSlicer:
 
 - Start **OrcaSlicer** and click on the icon for editing printer presets:
 
-    <img width="600" src="../../assets/img/OrcaSlicer/OrcaSlicer_01.png">
+    <img width="600" src="../assets/img/OrcaSlicer/OrcaSlicer_01.png">
 
 - Click on `Machine G-code` tab and define the following G-codes:
 
@@ -96,7 +96,7 @@ Here you will find custom build plates for OrcaSlicer:
 
 - In **OrcaSlicer**, click on `Connexion` icon:
 
-    <img width="600" src="../../assets/img/OrcaSlicer/OrcaSlicer_04.png">
+    <img width="600" src="../assets/img/OrcaSlicer/OrcaSlicer_04.png">
 
 - In `Hostname, IP or URL` section, enter the IP address of your printer depending Web interface you are using:
 
@@ -104,7 +104,7 @@ Here you will find custom build plates for OrcaSlicer:
     - For **Mainsail**: http://xxx.xxx.xxx.xxx:4409/ (replacing xxx.xxx.xxx.xxx by your local IP address)
     - If you have removed **Creality Web Interface**: http://xxx.xxx.xxx.xxx/ (replacing xxx.xxx.xxx.xxx by your local IP address)
 
-    <img width="600" src="../../assets/img/OrcaSlicer/OrcaSlicer_05.png">
+    <img width="600" src="../assets/img/OrcaSlicer/OrcaSlicer_05.png">
 
 - You can now upload Gcode files to your printer.
 
@@ -112,4 +112,4 @@ Here you will find custom build plates for OrcaSlicer:
 
 **If you like my work, don't hesitate to support me by paying me a 🍺 or a ☕. Thank you 🙂**
 
-<a href="https://ko-fi.com/guilouz" target="_blank"><img width="350" src="../../assets/img/home/Ko-fi.png"></a>
+<a href="https://ko-fi.com/guilouz" target="_blank"><img width="350" src="../assets/img/home/Ko-fi.png"></a>


### PR DESCRIPTION
The documentation about configuring Orca Slicer had problems with loading images. This change fixes relative image paths so the images are correctly displayed.

P.S. it looks like the issue happens on viewing pages directly on GitHub https://github.com/Guilouz/Creality-Helper-Script-Wiki/blob/main/docs/slicers/orcaslicer.md. The wiki page looks correct