### PR TITLE
Fix LGX retraction typo

### DIFF
--- a/docs/improvements/bondtech-lgx-pro-lite-upgrade-kit.md
+++ b/docs/improvements/bondtech-lgx-pro-lite-upgrade-kit.md
@@ -72,7 +72,7 @@ It’s needed to change extruder motor configuration.
 It’s needed to change retraction settings in your slicer:
 
 - **For 0.4mm nozzle:** 0.7mm length @ 35mm/s
-- **For 0.4mm nozzle:** 0.9mm length @ 35mm/s
+- **For 0.6mm nozzle:** 0.9mm length @ 35mm/s
 
 
 ## Use


### PR DESCRIPTION
Just a typo fix.

![image](https://github.com/user-attachments/assets/9d54ad0b-4848-4423-99bf-e30ce9fb1de6)
