### PR TITLE
feat: Use shallow clone in installation instructions

### DIFF
--- a/docs/helper-script/helper-script-installation.md
+++ b/docs/helper-script/helper-script-installation.md
@@ -20,7 +20,7 @@ If you have already installed Moonraker, Fluidd or Mainsail provided by Creality
 
 - Connect to SSH (Guide is available <a href="../../firmwares/ssh-connection">here</a>).
 
-- Enter the following command to install script in `usr/data` folder. **To reduce the size of the downloaded repository, a shallow clone with depth 1 is used:**
+- Enter the following command to install script in `usr/data` folder:
 
     ```
     git clone --depth 1 https://github.com/Guilouz/Creality-Helper-Script.git /usr/data/helper-script

--- a/docs/helper-script/helper-script-installation.md
+++ b/docs/helper-script/helper-script-installation.md
@@ -20,10 +20,10 @@ If you have already installed Moonraker, Fluidd or Mainsail provided by Creality
 
 - Connect to SSH (Guide is available <a href="../../firmwares/ssh-connection">here</a>).
 
-- Enter the following command to install script in `usr/data` folder:
+- Enter the following command to install script in `usr/data` folder. **To reduce the size of the downloaded repository, a shallow clone with depth 1 is used:**
 
     ```
-    git clone https://github.com/Guilouz/Creality-Helper-Script.git /usr/data/helper-script
+    git clone --depth 1 https://github.com/Guilouz/Creality-Helper-Script.git /usr/data/helper-script
     ```
 
 - And enter this command to run the script:


### PR DESCRIPTION
This pull request updates the installation instructions to use a shallow clone for the Helper Script repository.

**Motivation:**

The current instructions use a full clone, which can result in a large download size, especially for users with slower internet connections or limited storage on their 3D printer. By using a shallow clone with `git clone --depth 1`, we can greatly reduce the amount of data transferred during the initial setup process. This will lead to:

*   Faster initial installation times.
*   Reduced disk space usage on the printer.
*   Improved user experience, especially for users with limited bandwidth.

**Changes:**

*   The `git clone` command in the installation instructions is updated to:
    ```
    git clone --depth 1 https://github.com/Guilouz/Creality-Helper-Script.git /usr/data/helper-script
    ```
*   A sentence was added to explain the purpose of `depth 1`, which limits the download to the latest commit of the repo.

This change should be backwards-compatible and should not introduce any issues to existing users. It simply improves the initial setup experience for new users.

Please review and merge this PR at your convenience.